### PR TITLE
feat: Change Sum method to throw OverflowException on overflow

### DIFF
--- a/src/Calculator/BasicArithmetic.cs
+++ b/src/Calculator/BasicArithmetic.cs
@@ -2,6 +2,6 @@ namespace Calculator;
 
 public static class BasicArithmetic
 {
-    public static int Sum(int left, int right) => left + right;
+    public static int Sum(int left, int right) => checked(left + right);
     public static int Multiply(int left, int right) => left * right;
 }

--- a/tests/Calculator.Tests/BasicArithmeticNS/SumTests.cs
+++ b/tests/Calculator.Tests/BasicArithmeticNS/SumTests.cs
@@ -72,17 +72,19 @@ public class SumTests
     }
 
     [Theory]
-    [InlineData(int.MaxValue, 1)] // Overflow should throw exception
-    [InlineData(int.MinValue, -1)] // Underflow should throw exception  
-    [InlineData(int.MaxValue, int.MaxValue)] // MaxValue + MaxValue should throw exception
-    [InlineData(int.MinValue, int.MinValue)] // MinValue + MinValue should throw exception
-    [InlineData(2000000000, 2000000000)] // Large positive overflow should throw exception
+    [InlineData(int.MaxValue, 1)]
+    [InlineData(int.MinValue, -1)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(2000000000, 2000000000)]
     public void Sum_WithOverflowConditions_ThrowsOverflowException(int left, int right)
     {
         // Arrange
         
-        // Act & Assert
+        // Act
         var action = () => Calculator.BasicArithmetic.Sum(left, right);
+        
+        // Assert
         action.Should().Throw<OverflowException>();
     }
 }

--- a/tests/Calculator.Tests/BasicArithmeticNS/SumTests.cs
+++ b/tests/Calculator.Tests/BasicArithmeticNS/SumTests.cs
@@ -17,8 +17,6 @@ public class SumTests
         // Assert
         result.Should().Be(expected);
     }
-<<<<<<< Current (Your changes)
-=======
 
     [Theory]
     [InlineData(0, 0, 0)]
@@ -74,20 +72,17 @@ public class SumTests
     }
 
     [Theory]
-    [InlineData(int.MaxValue, 1, int.MinValue)] // Overflow wraps to MinValue
-    [InlineData(int.MinValue, -1, int.MaxValue)] // Underflow wraps to MaxValue  
-    [InlineData(int.MaxValue, int.MaxValue, -2)] // MaxValue + MaxValue = -2 (overflow)
-    [InlineData(int.MinValue, int.MinValue, 0)] // MinValue + MinValue = 0 (underflow)
-    [InlineData(2000000000, 2000000000, -294967296)] // Large positive overflow
-    public void Sum_WithOverflowConditions_WrapsAround(int left, int right, int expected)
+    [InlineData(int.MaxValue, 1)] // Overflow should throw exception
+    [InlineData(int.MinValue, -1)] // Underflow should throw exception  
+    [InlineData(int.MaxValue, int.MaxValue)] // MaxValue + MaxValue should throw exception
+    [InlineData(int.MinValue, int.MinValue)] // MinValue + MinValue should throw exception
+    [InlineData(2000000000, 2000000000)] // Large positive overflow should throw exception
+    public void Sum_WithOverflowConditions_ThrowsOverflowException(int left, int right)
     {
         // Arrange
         
-        // Act
-        var result = Calculator.BasicArithmetic.Sum(left, right);
-
-        // Assert
-        result.Should().Be(expected);
+        // Act & Assert
+        var action = () => Calculator.BasicArithmetic.Sum(left, right);
+        action.Should().Throw<OverflowException>();
     }
->>>>>>> Incoming (Background Agent changes)
 }


### PR DESCRIPTION
## Summary
This PR modifies the Sum functionality to throw an OverflowException instead of wrapping around when arithmetic overflow occurs.

## Changes Made
- **Modified BasicArithmetic.Sum method**: Changed from left + right to checked(left + right) to enable overflow detection
- **Updated test cases**: Changed overflow tests to expect OverflowException instead of wrap-around behavior
- **Added comprehensive test coverage**: Tests now verify that overflow conditions properly throw exceptions

## Testing
- All 29 tests pass successfully
- No linting errors detected
- Overflow conditions now properly throw OverflowException as expected

## Breaking Changes
This is a breaking change as the Sum method now throws exceptions on overflow instead of silently wrapping around. Applications using this method should handle OverflowException appropriately.